### PR TITLE
Add customizable duration for toast messages

### DIFF
--- a/projects/ngx-toastr-message/README.md
+++ b/projects/ngx-toastr-message/README.md
@@ -85,5 +85,12 @@ lucida: "'Lucida Sans Unicode', sans-serif",
 impact: "Impact, sans-serif",
 ```
 
+3. Change the duration (in milliseconds):
+```typescript
+this.toastrService.show('This is a success message!', 'success', {
+  duration: 5000 // Shows for 5 seconds
+});
+```
+
 ### License
 MIT

--- a/projects/ngx-toastr-message/src/lib/ngx-toastr-message.component.ts
+++ b/projects/ngx-toastr-message/src/lib/ngx-toastr-message.component.ts
@@ -65,7 +65,9 @@ export class NgxToastrMessageComponent implements OnInit {
   ngOnInit(): void {
     this.ngxToastrMessageService.messages$.subscribe((message) => {
       this.messages.push(message);
-      setTimeout(() => this.removeMessage(message), 3000);
+      const duration = message.options?.duration || 3000; 
+      //setTimeout uses duration to display message for a certain time
+      setTimeout(() => this.removeMessage(message), duration);
     });
   }
 

--- a/projects/ngx-toastr-message/src/lib/ngx-toastr-message.service.ts
+++ b/projects/ngx-toastr-message/src/lib/ngx-toastr-message.service.ts
@@ -7,7 +7,8 @@ export interface ToasterMessage {
   type: 'success' | 'error' | 'info' | 'warning';
   options?: {
     fontSize?: number;
-    font?: keyof typeof PREDEFINED_FONTS
+    font?: keyof typeof PREDEFINED_FONTS;
+    duration?: number; //added
   };
 }
 
@@ -22,7 +23,11 @@ export class NgxToastrMessageService {
   show(
     message: string,
     type: 'success' | 'error' | 'info' | 'warning',
-    options?: { fontSize?: number; font?: keyof typeof PREDEFINED_FONTS  }
+    options?: { 
+      fontSize?: number; 
+      font?: keyof typeof PREDEFINED_FONTS;
+      duration?: number; //added
+    }
   ) {
     this.messageSubject.next({ message, type, options });
   }


### PR DESCRIPTION
- Add duration option to ToasterMessage interface
- Implement duration handling in NgxToastrMessageComponent
- Default duration set to 3000ms if not specified
- Update README with duration customization example

Example usage:
toastrService.show('message', 'success', { duration: 5000 })