### PR TITLE
added icons to each message category

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -65,6 +65,7 @@
               }
             ],
             "styles": [
+              "node_modules/font-awesome/css/font-awesome.min.css",
               "projects/my-app/src/styles.scss"
             ],
             "scripts": []
@@ -124,6 +125,7 @@
               }
             ],
             "styles": [
+              "node_modules/font-awesome/css/font-awesome.min.css",
               "projects/my-app/src/styles.scss"
             ],
             "scripts": []

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/router": "^18.0.0",
+        "font-awesome": "^4.7.0",
         "ngx-toastr-message": "file:dist/ngx-toastr-message",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
@@ -7425,6 +7426,15 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/font-awesome": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
+      "integrity": "sha512-U6kGnykA/6bFmg1M/oT9EkFeIYv7JlX3bozwQJWiiLz6L0w3F5vBVPxHlwyX/vtNq1ckcpRKOB9f2Qal/VtFpg==",
+      "license": "(OFL-1.1 AND MIT)",
+      "engines": {
+        "node": ">=0.10.3"
       }
     },
     "node_modules/foreground-child": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/router": "^18.0.0",
+    "font-awesome": "^4.7.0",
     "ngx-toastr-message": "file:dist/ngx-toastr-message",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/projects/my-app/src/app/app.component.ts
+++ b/projects/my-app/src/app/app.component.ts
@@ -16,7 +16,7 @@ export class AppComponent {
   private toastrService = inject(NgxToastrMessageService);
   title = 'my-app';
   showMessage() {
-    this.toastrService.show('This is a success message!', 'success', {
+    this.toastrService.show('This is a success message!', 'warning', {
       fontSize: 10,
       font: 'impact',
       duration:2000,

--- a/projects/ngx-toastr-message/src/lib/ngx-toastr-message.component.ts
+++ b/projects/ngx-toastr-message/src/lib/ngx-toastr-message.component.ts
@@ -14,13 +14,18 @@ import { PREDEFINED_FONTS } from './fonts';
     <div class="toaster-container">
      @for (message of messages; track message) {
       <div
-        class="toaster-message"
-        [ngClass]="[message.type, getPositionClass(message)]"
-        [style.fontSize.px]="message.options?.fontSize"
-        [style.fontFamily]="message.options?.font ? PREDEFINED_FONTS[message.options?.font!] : 'inherit'"
-      >
-        {{ message.message }}
-      </div>
+          class="toaster-message"
+          [ngClass]="[message.type, getPositionClass(message)]"
+          [style.fontSize.px]="message.options?.fontSize"
+          [style.fontFamily]="message.options?.font ? PREDEFINED_FONTS[message.options?.font!] : 'inherit'"
+        >
+          <div class="toast-content">
+            <span class="toast-icon">
+              <i [class]="getIconClass(message)"></i>
+            </span>
+            <span class="toast-text">{{ message.message }}</span>
+          </div>
+        </div>
     }
     </div>
   `,
@@ -30,6 +35,11 @@ import { PREDEFINED_FONTS } from './fonts';
   top: 20px;
   right: 20px;
   z-index: 1000;
+}
+
+.toast-icon {
+  margin-right: 8px;
+  font-size: 18px;
 }
 
 .toaster-message {
@@ -86,5 +96,22 @@ export class NgxToastrMessageComponent implements OnInit {
 
   getPositionClass(message: ToasterMessage): string {
     return message.options?.position || 'top-right';
+  }
+
+  getIconClass(message: ToasterMessage): string {
+    if (message.options?.icon) return message.options.icon; // custom icon support
+
+    switch (message.type) {
+      case 'success':
+        return 'fa fa-check-circle';
+      case 'error':
+        return 'fa fa-times-circle';
+      case 'info':
+        return 'fa fa-info-circle';
+      case 'warning':
+        return 'fa fa-exclamation-triangle';
+      default:
+        return 'fa fa-bell';
+    }
   }
 }

--- a/projects/ngx-toastr-message/src/lib/ngx-toastr-message.service.ts
+++ b/projects/ngx-toastr-message/src/lib/ngx-toastr-message.service.ts
@@ -9,6 +9,7 @@ export interface ToasterMessage {
     fontSize?: number;
     font?: keyof typeof PREDEFINED_FONTS;
     duration?: number; //added
+    icon?: string;
     position?: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left' | 'top-center' | 'bottom-center';//positions
   };
 }
@@ -21,6 +22,22 @@ export class NgxToastrMessageService {
   public messages$ = this.messageSubject.asObservable();
   constructor() {}
 
+  private getIcon(type: 'success' | 'error' | 'info' | 'warning'): string {
+    // Choose default icons for each type
+    switch (type) {
+      case 'success':
+        return 'fa fa-check-circle';
+      case 'error':
+        return 'fa fa-times-circle';
+      case 'info':
+        return 'fa fa-info-circle';
+      case 'warning':
+        return 'fa fa-exclamation-triangle';
+      default:
+        return 'fa fa-bell';
+    }
+  }
+
   show(
     message: string,
     type: 'success' | 'error' | 'info' | 'warning',
@@ -28,6 +45,7 @@ export class NgxToastrMessageService {
       fontSize?: number;
       font?: keyof typeof PREDEFINED_FONTS;
       duration?: number; //added
+      icon?: string;
       position?: 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left' | 'top-center' | 'bottom-center';//positions
     }
   ) {


### PR DESCRIPTION
Here message icons used from font awsome :

case 'success':
        return 'fa fa-check-circle';
      case 'error':
        return 'fa fa-times-circle';
      case 'info':
        return 'fa fa-info-circle';
      case 'warning':
        return 'fa fa-exclamation-triangle';
      default:
        return 'fa fa-bell';
        
Sample:
<img width="187" height="74" alt="image" src="https://github.com/user-attachments/assets/d66b9456-1b65-4244-a568-92ee6f9fb7cb" />
